### PR TITLE
Set .NET runtime to .NET 10 in setup.ps1

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -54,6 +54,13 @@ $app = az functionapp create --name $AppName --resource-group $resourceGroup `
 if (-not $?) {
     throw "Unable to set up Functions app"
 }
+
+Write-Output "Setting .NET runtime to .NET 10"
+az functionapp config set `
+    --name $AppName `
+    --resource-group $resourceGroup `
+    --net-framework-version v10.0 > $null
+
 $hostname = $app.defaultHostName
 Write-Output "Functions app host is $hostname"
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -49,7 +49,7 @@ $app = az functionapp create --name $AppName --resource-group $resourceGroup `
     --plan $PlanName `
     --functions-version "4" `
     --runtime dotnet-isolated `
-    --runtime-version 10.0 `    
+    --runtime-version 10.0 ` 
     --disable-app-insights true `
     --https-only true `
     --tags $packageTag $runnerOsTag $dateTag | ConvertFrom-Json

--- a/setup.ps1
+++ b/setup.ps1
@@ -48,18 +48,14 @@ $app = az functionapp create --name $AppName --resource-group $resourceGroup `
     --storage-account $StorageName `
     --plan $PlanName `
     --functions-version "4" `
+    --runtime dotnet-isolated `
+    --runtime-version 10.0 `    
     --disable-app-insights true `
     --https-only true `
     --tags $packageTag $runnerOsTag $dateTag | ConvertFrom-Json
 if (-not $?) {
     throw "Unable to set up Functions app"
 }
-
-Write-Output "Setting .NET runtime to .NET 10"
-az functionapp config set `
-    --name $AppName `
-    --resource-group $resourceGroup `
-    --net-framework-version v10.0 > $null
 
 $hostname = $app.defaultHostName
 Write-Output "Functions app host is $hostname"

--- a/setup.ps1
+++ b/setup.ps1
@@ -49,7 +49,7 @@ $app = az functionapp create --name $AppName --resource-group $resourceGroup `
     --plan $PlanName `
     --functions-version "4" `
     --runtime dotnet-isolated `
-    --runtime-version "10.0" ` 
+    --runtime-version "10.0" `
     --disable-app-insights true `
     --https-only true `
     --tags $packageTag $runnerOsTag $dateTag | ConvertFrom-Json

--- a/setup.ps1
+++ b/setup.ps1
@@ -49,7 +49,7 @@ $app = az functionapp create --name $AppName --resource-group $resourceGroup `
     --plan $PlanName `
     --functions-version "4" `
     --runtime dotnet-isolated `
-    --runtime-version 10.0 ` 
+    --runtime-version "10.0" ` 
     --disable-app-insights true `
     --https-only true `
     --tags $packageTag $runnerOsTag $dateTag | ConvertFrom-Json

--- a/setup.ps1
+++ b/setup.ps1
@@ -49,7 +49,7 @@ $app = az functionapp create --name $AppName --resource-group $resourceGroup `
     --plan $PlanName `
     --functions-version "4" `
     --runtime dotnet-isolated `
-    --runtime-version "10.0" `
+    --runtime-version "10" `
     --disable-app-insights true `
     --https-only true `
     --tags $packageTag $runnerOsTag $dateTag | ConvertFrom-Json


### PR DESCRIPTION
Update .NET runtime version to .NET 10 in setup script.

Gets rid of

> WARNING: Use dotnet version 8 as 8 will reach end-of-life on 2026-11-10 and will no longer be supported. 